### PR TITLE
Fix control letter indexing

### DIFF
--- a/iscif.js
+++ b/iscif.js
@@ -12,7 +12,7 @@ var iscif = ((typeof module === 'object') ? module : {}).exports = function (cif
   // CIF should be 9 characters
   var unverifiednum = String(cif).replace(/[\-]/gi, '').toUpperCase(),
       letters = "ABCDEFGHJKLMNPRQSUVW", a, b, oddNumbers, x, c, d, e, i, len,
-      letters2 = "ABCDEFGHIJ", letter, provinceCode, number, controlCode;
+      letters2 = "JABCDEFGHI", letter, provinceCode, number, controlCode;
   
 
   if (!unverifiednum.match(/^[ABCDEFGHJKLMNPRQSUVW]\d{7}[\d[ABCDEFGHIJ]$/)) {


### PR DESCRIPTION
The CIF format algorithm use a control letter in some cases (When the legal nature is Q for example).

However, as defined on [this website](http://www.jagar.es/economia/ccif.htm):
```
A = 1, B = 2, C = 3, D = 4, E = 5, F = 6, G = 7, H = 8, I = 9, J = 10 or 0
```

This means that `J` should be at index `0` of the `letters2` string. Otherwise, all letters are actually shifted by 1.